### PR TITLE
uncheck the WP button when the WP popup is closed

### DIFF
--- a/times.py
+++ b/times.py
@@ -952,7 +952,7 @@ class WorkPackageView(QtWidgets.QDialog):
                 return self.getMainWindow(parent.parent())
         else:
             return None
-        
+
     def closeEvent(self, event):
         mainWnd = self.getMainWindow(self.parent())
         mainWnd.workpackagesButton.setChecked(False)


### PR DESCRIPTION
since the recent changes to the work packages (attached view, WP button active state) closing the WP popup would not disable the WP active state and made it necessary to deactivate and activate the button again (basically double click it)

this is fixed with this PR