### PR TITLE
Bump shiboken6 from 6.6.0 to 6.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pywin32-ctypes==0.2.2
 requests==2.31.0
 requests-oauthlib==1.3.1
 requests-toolbelt==1.0.0
-shiboken6==6.6.0
+shiboken6==6.6.1
 tomli==2.0.1
 typing_extensions==4.8.0
 urllib3==2.1.0


### PR DESCRIPTION
Bumps [shiboken6]() from 6.6.0 to 6.6.1.

---
updated-dependencies:
- dependency-name: shiboken6 dependency-type: direct:production update-type: version-update:semver-patch ...