### PR TITLE
small detailed time window fixes

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -129,7 +129,6 @@ class DetailTimesDialog(QtWidgets.QDialog):
         h = QtCore.QTime.currentTime().hour()
         m = QtCore.QTime.currentTime().minute()
         timeEdit.setTime(QtCore.QTime(h, m))
-        self.updateDiffs()
 
     def updateDiffs(self):
         self.totalDiff = 0


### PR DESCRIPTION
detailed time window now updates time calculation (for the line and the day) on time change.
it correctly updates with the button fixing #86 
the inputs are now using only minutes and hours instead of seconds 