### PR TITLE
Fix opening many times

### DIFF
--- a/times.py
+++ b/times.py
@@ -1098,6 +1098,10 @@ def start_GUI() -> None:
                 file.unlink()
 
     lockfile = Path(f"lockfile_{time.time()}")
+    if lockfile.exists():
+        # fix possible unique name conflict
+        time.sleep(1)
+        lockfile = Path(f"lockfile_{time.time()}")
     if alreadyRunning:
         if window:
             ret = QtWidgets.QMessageBox.warning(

--- a/times.py
+++ b/times.py
@@ -1150,7 +1150,7 @@ def findWindow(pid: int) -> int | None:
     top_windows = []
     win32gui.EnumWindows(windowEnumerationHandler, top_windows)
     for i in top_windows:
-        if pid == i[2] and i[1] == "UltraTime":
+        if pid == i[2] and i[1].startswith("Times "):
             result = i[0]
     return result
 

--- a/times.py
+++ b/times.py
@@ -1083,40 +1083,49 @@ def start_GUI() -> None:
     app.setWindowIcon(QtGui.QPixmap(resource_path("time.png")))
     app.setQuitOnLastWindowClosed(False)
 
-    lockfile = Path("lockfile")
     start = True
-    if lockfile.exists():
-        with lockfile.open("r") as fp:
-            pid = int(fp.read())
-        if psutil.pid_exists(pid) and psutil.Process(pid).name() in ["times.exe", "python.exe"]:
-            window = findWindow(pid)
-            if window:
-                ret = QtWidgets.QMessageBox.warning(
-                    QtWidgets.QWidget(),
-                    "UltraTime already running",
-                    "Do you want to start a second instance?\n\n"
-                    "It might lead to inconsistencies or overwriting of time data!\n"
-                    "Click open to activate the first instance",
-                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No | QtWidgets.QMessageBox.Open,
-                    QtWidgets.QMessageBox.Open,
-                )
-            else:
-                ret = QtWidgets.QMessageBox.warning(
-                    QtWidgets.QWidget(),
-                    "UltraTime already running",
-                    "Do you want to start a second instance?\n\nIt might lead to inconsistencies or overwriting of time data!",
-                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                    QtWidgets.QMessageBox.No,
-                )
-            if QtWidgets.QMessageBox.No == ret:
-                start = False
-                logging.info("Aborted starting")
-            if QtWidgets.QMessageBox.Open == ret:
-                start = False
-                shell = win32com.client.Dispatch("WScript.Shell")
-                shell.SendKeys("%")
-                win32gui.SetForegroundWindow(window)
-                logging.info("Aborted starting - Showed other instance instead")
+    # look for any lockfile
+    alreadyRunning = False
+    p = Path()
+    for file in p.iterdir():
+        if file.is_file and file.name.startswith("lockfile"):
+            with file.open("r") as fp:
+                pid = int(fp.read())
+                if psutil.pid_exists(pid) and psutil.Process(pid).name() in ["times.exe", "python.exe"]:
+                    alreadyRunning = True
+                    window = findWindow(pid)
+                    break
+                file.unlink()
+
+    lockfile = Path(f"lockfile_{time.time()}")
+    if alreadyRunning:
+        if window:
+            ret = QtWidgets.QMessageBox.warning(
+                QtWidgets.QWidget(),
+                "Times already running",
+                "Do you want to start a second instance?\n\n"
+                "It might lead to inconsistencies or overwriting of time data!\n"
+                "Click open to activate the first instance",
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No | QtWidgets.QMessageBox.Open,
+                QtWidgets.QMessageBox.Open,
+            )
+        else:
+            ret = QtWidgets.QMessageBox.warning(
+                QtWidgets.QWidget(),
+                "Times already running",
+                "Do you want to start a second instance?\n\nIt might lead to inconsistencies or overwriting of time data!",
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.No,
+            )
+        if QtWidgets.QMessageBox.No == ret:
+            start = False
+            logging.info("Aborted starting")
+        if QtWidgets.QMessageBox.Open == ret:
+            start = False
+            shell = win32com.client.Dispatch("WScript.Shell")
+            shell.SendKeys("%")
+            win32gui.SetForegroundWindow(window)
+            logging.info("Aborted starting - Showed other instance instead")
 
     if start:
         lockfile.write_text(str(os.getpid()))


### PR DESCRIPTION
Before this change the lockfile always had the same name.
If Times.exe was started a second time and opened it would write into the same file.
If any of the 2 instances got closed the lockfile got deleted as well.

--> Locking mechanism was broken from this time on.
--> Closing the 2nd instance threw an error that the lockfile could not be deleted.

Now every instance creates  a unique lockfile to prevent that issue.

If a lockfile with the same timestamp already exists we sleep 1 second - little bit ugly but most effective.

Also: someone forgot to fix name references after renaming the tool --> fixed that so that windows can be found again.
